### PR TITLE
Support different types of transaction as subcommand and support circle transfer transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ RPC_URL=your_rpc_url
 Run the application with the following command:
 
 ```bash
-cargo run --release -- -t <tx-count> -n <num-accounts> -f <funding-amount-tssc> -s <set_array_count> <SUBCOMMAND>
+cargo run --release -- -t <tx-count> -n <num-accounts> -f <funding-amount-tssc> <SUBCOMMAND>
 ```
 
 - `-t, --tx_count <tx_count>`: The number of transactions to generate.

--- a/README.md
+++ b/README.md
@@ -43,10 +43,13 @@ RPC_URL=your_rpc_url
 Run the application with the following command:
 
 ```bash
-cargo run --release -- -t <tx_count> -n <num_accounts> -f <funding_amount_tssc> -s <set_array_count>
+cargo run --release -- -t <tx-count> -n <num-accounts> -f <funding-amount-tssc> -s <set_array_count> <SUBCOMMAND>
 ```
 
 - `-t, --tx_count <tx_count>`: The number of transactions to generate.
-- `-a, --num_accounts <num_accounts>`: The number of accounts to use for generating transactions.
+- `-n, --num_accounts <num_accounts>`: The number of accounts to use for generating transactions.
 - `-f, --funding_amount_tssc <funding_amount_tssc>`: The amount of TSSC to fund the accounts with.
-- `-s, --set_array_acounts <set_array_count>`: This larger this value, the more each transaction will cost. Reasonable values are 1-1000.
+
+`<SUBCOMMAND>`: different types of transaction that can be generated:
+- `set-array`: Generate transaction with given weight/size
+- `chain-transfer`: Generate chain of transfer transaction, i.e. A->B, B->C, ..

--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ cargo run --release -- -t <tx-count> -n <num-accounts> -f <funding-amount-tssc> 
 `<SUBCOMMAND>`: different types of transaction that can be generated:
 - `set-array`: Generate transaction with given weight/size
 - `chain-transfer`: Generate chain of transfer transaction, i.e. A->B, B->C, ..
+- `circle-transfer`: Generate circle of transfer transaction, i.e. A->B, B->C, C->A

--- a/src/generate_transactions.rs
+++ b/src/generate_transactions.rs
@@ -1,22 +1,9 @@
-use std::sync::Arc;
-
 use crate::{contract_calls::*, transaction_manager::TransactionManager, CHAIN_ID};
 use ethers::prelude::*;
 use eyre::Result;
 use log::info;
-
-pub enum TransactionType {
-    Transfer(U256),
-    SetArray {
-        contract_address: Address,
-        count: U256,
-    },
-    BulkTransfer {
-        to_addresses: Vec<Address>,
-        funding_amount: U256,
-        contract_address: Address,
-    },
-}
+use std::sync::Arc;
+use std::time::Duration;
 
 pub async fn generate_and_send_transfer(
     tx_manager: &TransactionManager,
@@ -46,70 +33,20 @@ pub async fn generate_and_send_transfer(
     Ok(recipient_tx_manager)
 }
 
-async fn generate_and_send_set_array(
-    tx_manager: &TransactionManager,
+pub async fn generate_and_send_set_array(
+    tx_manager: TransactionManager,
+    num_transactions: usize,
     load_contract_address: Address,
     count: U256,
-) -> Result<()> {
-    let tx = set_array_transaction(load_contract_address, count)?;
-    tx_manager.handle_transaction(tx).await?;
-
-    Ok(())
-}
-
-async fn generate_and_send_bulk_transfer(
-    transaction_manager: &TransactionManager,
-    to_addresses: Vec<Address>,
-    funding_amount: U256,
-    contract_address: Address,
-) -> Result<()> {
-    let tx = bulk_transfer_transaction(to_addresses, funding_amount, contract_address)?;
-    transaction_manager.handle_transaction(tx).await?;
-
-    Ok(())
-}
-
-pub async fn send_continuous_transactions(
-    transaction_manager: TransactionManager,
-    num_transactions: usize,
-    transaction_type: &TransactionType,
 ) -> Result<()> {
     for i in 0..num_transactions {
         info!(
             "Transaction #{} for wallet {:?}",
             i + 1,
-            transaction_manager.get_address()
+            tx_manager.get_address()
         );
-        let _ = match transaction_type {
-            TransactionType::Transfer(amount) => {
-                generate_and_send_transfer(&transaction_manager, amount).await?;
-                Ok(())
-            }
-            TransactionType::SetArray {
-                contract_address,
-                count,
-            } => {
-                generate_and_send_set_array(
-                    &transaction_manager,
-                    contract_address.clone(),
-                    count.clone(),
-                )
-                .await
-            }
-            TransactionType::BulkTransfer {
-                to_addresses,
-                funding_amount,
-                contract_address,
-            } => {
-                generate_and_send_bulk_transfer(
-                    &transaction_manager,
-                    to_addresses.clone(),
-                    funding_amount.clone(),
-                    contract_address.clone(),
-                )
-                .await
-            }
-        };
+        let tx = set_array_transaction(load_contract_address, count)?;
+        tx_manager.handle_transaction(tx).await?;
     }
 
     Ok(())
@@ -118,23 +55,23 @@ pub async fn send_continuous_transactions(
 pub async fn chain_of_transfers(
     transaction_manager: TransactionManager,
     num_transactions: usize,
-    amount: U256,
+    mut transfer_amount: U256,
 ) -> Result<()> {
     let gas = 1.2e13 as u64;
     let mut next_tx_manager = transaction_manager.clone();
 
-    for i in 0..num_transactions {
-        let transfer_amount: U256 = amount - ((i + 1) as u64 * gas);
+    for i in 1..=num_transactions {
         if transfer_amount <= (1e14 as u128).into() {
-            info!("Insufficient funds for transaction #{}", i + 1);
+            info!("Insufficient funds for transaction #{}", i);
             break;
         }
         info!(
             "Transaction #{} for wallet {:?}",
-            i + 1,
+            i,
             next_tx_manager.get_address()
         );
 
+        transfer_amount -= gas.into();
         next_tx_manager = generate_and_send_transfer(&next_tx_manager, &transfer_amount).await?;
     }
     Ok(())

--- a/src/generate_transactions.rs
+++ b/src/generate_transactions.rs
@@ -61,7 +61,7 @@ pub async fn chain_of_transfers(
     let mut next_tx_manager = transaction_manager.clone();
 
     for i in 1..=num_transactions {
-        if transfer_amount <= (1e14 as u128).into() {
+        if transfer_amount <= gas.into() {
             info!("Insufficient funds for transaction #{}", i);
             break;
         }

--- a/src/generate_transactions.rs
+++ b/src/generate_transactions.rs
@@ -76,3 +76,102 @@ pub async fn chain_of_transfers(
     }
     Ok(())
 }
+
+pub async fn circle_of_transfers(
+    transaction_manager: TransactionManager,
+    tx_mgrs: Vec<TransactionManager>,
+    init_fund: U256,
+    interval_second: usize,
+    tx_count: usize,
+) -> Result<()> {
+    assert!(tx_mgrs.len() > 1);
+    let first_sender = tx_mgrs[0].get_address();
+    let last_receiver = tx_mgrs[tx_mgrs.len() - 1].clone();
+    let transfer_pairs: Vec<_> = tx_mgrs
+        .into_iter()
+        .map_windows(|[x, y]| (x.clone(), y.get_address()))
+        .chain(vec![(last_receiver, first_sender)])
+        .collect();
+    let total_pairs = transfer_pairs.len();
+    let last_holder_index = transfer_pairs.len() - 1;
+
+    // Send `holder_fund` to the first account
+    let holder_fund = init_fund * 2;
+    let tx = TransactionRequest::new()
+        .to(first_sender)
+        .value(holder_fund)
+        .from(transaction_manager.get_address());
+    transaction_manager.handle_transaction(tx).await?;
+
+    let mut round = 0;
+    let mut round_started_at = 0;
+    let mut holder_index = 0;
+    let mut round_ended = false;
+    for iteration in 0..tx_count {
+        let gas_price = transaction_manager.client.get_gas_price().await.ok();
+        for (i, (sender, receiver)) in transfer_pairs.iter().enumerate() {
+            let transfer_amount = if i == holder_index {
+                holder_fund + U256::from(iteration)
+            } else {
+                U256::from(iteration)
+            };
+            let mut tx = TransactionRequest::new()
+                .from(sender.get_address())
+                .to(*receiver)
+                .value(transfer_amount);
+
+            // Always pay more gas to replace the previous tx with the same nonce
+            if let Some(gp) = gas_price {
+                tx = tx.gas_price(gp + U256::from(iteration));
+            }
+
+            if let Err(err) = sender.client.send_transaction(tx, None).await {
+                log::info!(
+                    "Error sending transaction for account #{}, err: {err:?}",
+                    i + 1
+                );
+            }
+        }
+
+        // Sleep for `interval_second` to give some time for the tx propagate to other nodes
+        // and maybe included in the bundle/block
+        tokio::time::sleep(Duration::from_secs(interval_second as u64)).await;
+
+        // Check who currently hold the `holder_fund` starting from the previous holder
+        // and move to the next round if possible
+        let check_balance_iter = transfer_pairs
+            .iter()
+            .enumerate()
+            .cycle()
+            .skip(holder_index)
+            .take(total_pairs);
+        for (i, (sender, _)) in check_balance_iter {
+            let balance = transaction_manager
+                .client
+                .get_balance(sender.get_address(), None)
+                .await
+                .unwrap_or(0.into());
+            if balance >= holder_fund {
+                info!("Holder fund transfer to account #{}", i + 1);
+                holder_index = i;
+
+                // Start a new round if the `holder_fund` just transferred from the last account to the first
+                if round_ended && holder_index == 0 {
+                    round += 1;
+                    let took = iteration - round_started_at;
+                    round_started_at = iteration;
+                    info!(
+                        "Start round #{round} transfer, last round took {took} iterations, \
+                        total run {iteration} iterations"
+                    );
+                }
+                // Round ended when the `holder_fund` transferred to the last account
+                round_ended = holder_index == last_holder_index;
+
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,11 @@ enum TransactionType {
     },
     /// Generate chain of transfer transaction, i.e. A->B, B->C, ..
     ChainTransfer,
+    /// Generate circle of transfer transaction, i.e. A->B, B->C, C->A
+    CircleTransfer {
+        /// Interval between transactions
+        interval_second: usize,
+    },
 }
 
 struct EnvVars {
@@ -151,6 +156,16 @@ async fn main() -> Result<(), Report> {
                 .collect::<Vec<_>>();
 
             try_join_all(transactions).await?;
+        }
+        TransactionType::CircleTransfer { interval_second } => {
+            circle_of_transfers(
+                funder_tx_manager,
+                acc_tx_mgrs,
+                funding_amount,
+                interval_second,
+                tx_count,
+            )
+            .await?;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(iter_map_windows)]
+
 mod contract_calls;
 mod generate_transactions;
 mod transaction_manager;
@@ -6,7 +8,7 @@ use contract_calls::*;
 use env_logger::Builder;
 use ethers::prelude::*;
 use eyre::{Report, Result};
-use futures::future::join_all;
+use futures::future::try_join_all;
 use generate_transactions::*;
 use log::LevelFilter;
 use std::env;
@@ -23,17 +25,27 @@ struct Opt {
     #[structopt(short, long)]
     num_accounts: usize,
 
-    // The number of transactions to generate
-    #[structopt(short, long)]
-    tx_count: usize,
-
     // The amount of funding to send to each account
     #[structopt(short, long)]
     funding_amount_tssc: f64,
 
-    // measurement of how heavy a transaction should be, values between 1-2000 are appropriate
+    // The number of transactions to generate
     #[structopt(short, long)]
-    set_array_count: u64,
+    tx_count: usize,
+
+    #[structopt(subcommand)]
+    tx_type: TransactionType,
+}
+
+#[derive(StructOpt, Debug)]
+enum TransactionType {
+    /// Generate transaction with given weight/size
+    SetArray {
+        /// Measurement of how heavy a transaction should be, values between 1-2000 are appropriate
+        set_array_count: U256,
+    },
+    /// Generate chain of transfer transaction, i.e. A->B, B->C, ..
+    ChainTransfer,
 }
 
 struct EnvVars {
@@ -85,40 +97,62 @@ async fn main() -> Result<(), Report> {
 
     // Parse command-line arguments
     let Opt {
-        tx_count,
         num_accounts,
         funding_amount_tssc,
-        set_array_count,
+        tx_count,
+        tx_type,
     } = Opt::from_args();
 
     let provider = Arc::new(Provider::<Http>::try_from(rpc_url).map_err(Report::msg)?);
-    let funder_wallet: LocalWallet = funder_private_key.parse()?;
-    let funder_wallet = funder_wallet.clone().with_chain_id(CHAIN_ID);
-    let funder_tx_manager = TransactionManager::new(provider.clone(), &funder_wallet);
-
-    let wallets = (0..num_accounts)
-        .map(|_| Wallet::new(&mut rand::thread_rng()).with_chain_id(CHAIN_ID))
-        .collect::<Vec<_>>();
-    let addresses = wallets.iter().map(|w| w.address()).collect::<Vec<_>>();
-    let funding_amount: U256 = ((funding_amount_tssc * 1e18) as u128).into();
-    let tx = bulk_transfer_transaction(addresses, funding_amount, fund_contract_address)?;
-
-    funder_tx_manager.handle_transaction(tx).await?;
-
-    let transaction_type = TransactionType::SetArray {
-        contract_address: load_contract_address,
-        count: set_array_count.into(),
+    let funder_tx_manager = {
+        let funder_wallet = funder_private_key
+            .parse::<LocalWallet>()?
+            .with_chain_id(CHAIN_ID);
+        TransactionManager::new(provider.clone(), &funder_wallet)
     };
-    // Transaction generation and sending
-    let transactions = wallets
-        .iter()
-        .map(|w| {
-            let tx_manager = TransactionManager::new(provider.clone(), &w);
-            chain_of_transfers(tx_manager, tx_count, funding_amount)
-            //send_continuous_transactions(tx_manager.clone(), tx_count, &transaction_type)
-        })
+    let funding_amount: U256 = ((funding_amount_tssc * 1e18) as u128).into();
+    let acc_tx_mgrs = (0..num_accounts)
+        .map(|_| Wallet::new(&mut rand::thread_rng()).with_chain_id(CHAIN_ID))
+        .map(|w| TransactionManager::new(provider.clone(), &w))
         .collect::<Vec<_>>();
 
-    let _results = join_all(transactions).await;
+    // Initial fund for accounts
+    let initial_fund_tx = {
+        let addresses = acc_tx_mgrs
+            .iter()
+            .map(|w| w.get_address())
+            .collect::<Vec<_>>();
+        bulk_transfer_transaction(addresses, funding_amount, fund_contract_address)?
+    };
+    funder_tx_manager
+        .handle_transaction(initial_fund_tx)
+        .await?;
+
+    match tx_type {
+        TransactionType::SetArray { set_array_count } => {
+            let transactions = acc_tx_mgrs
+                .into_iter()
+                .map(|tx_mgr| {
+                    generate_and_send_set_array(
+                        tx_mgr,
+                        tx_count,
+                        load_contract_address,
+                        set_array_count,
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            try_join_all(transactions).await?;
+        }
+        TransactionType::ChainTransfer => {
+            let transactions = acc_tx_mgrs
+                .into_iter()
+                .map(|tx_mgr| chain_of_transfers(tx_mgr, tx_count, funding_amount))
+                .collect::<Vec<_>>();
+
+            try_join_all(transactions).await?;
+        }
+    }
+
     Ok(())
 }

--- a/src/transaction_manager.rs
+++ b/src/transaction_manager.rs
@@ -68,7 +68,7 @@ impl TransactionManager {
                 }
                 Err(e) => {
                     error!("Error sending transaction, giving up: {:?}", e);
-                    return Err(e.into());
+                    return Err(e);
                 }
             }
         }


### PR DESCRIPTION
This PR bring some refactoring to support different types of transaction as subcommand, so we can specify which type of transaction through command line like (use `--help` to see more detail):
```bash
evm-tx --funding-amount-tssc 0.1 --num-accounts 5 --tx-count 10000 chain-transfer
evm-tx --funding-amount-tssc 0.1 --num-accounts 5 --tx-count 10000 set-array 100
```

This PR also supports circle transfer transaction:
```bash
evm-tx --funding-amount-tssc <funding-amount-tssc> --num-accounts <num-accounts> --tx-count <tx-count> circle-transfer <interval-second>
```

It is a type of transaction similar to chain transfer but different in a few ways:
- It is transferring a `holder_fund` in a circle, i.e. A->B, B->C, .., E->A, it will stop either a) all initial fund is used as gas fee and it is run out of gas. b) the specified `-t <tx-count>` is met.
- Every account will transfer a small fund (which it always has) at the same time to its receiver account even if it doesn't have the `holder_fund`
- It doesn't wait for any confirmation but just sleep for the specified `interval-second` before generating the next round of transaction

In such a way, the `circle-transfer` will actively generate illegal transactions with invalid nonce and insufficient funds, thus it is expected to see error/warning log when running this subcommand.
